### PR TITLE
add fallback for blank $movID

### DIFF
--- a/04 MEI cleaning/improveMusic.xsl
+++ b/04 MEI cleaning/improveMusic.xsl
@@ -108,7 +108,7 @@
     </xd:doc>
     <xsl:template match="mei:mdiv" mode="lastRun">
         <xsl:copy>
-            <xsl:attribute name="xml:id" select="$movID"/>
+            <xsl:attribute name="xml:id" select="if($movID!='')then($movID)else(generate-id(.))"/>
             <xsl:apply-templates select="@* | node()" mode="#current"/>
         </xsl:copy>
     </xsl:template>


### PR DESCRIPTION
Although the stylesheet was designed in a context that always required
a mdiv element to have a xml:id, it also was in a context where only
one mdiv was being processed at a time.
This commit introduces a fallback to fn:generate-id() if $movID is blank
